### PR TITLE
check if `$options.inter` exists in the root Vue instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,9 @@ export default class Inter {
     Vue.mixin({
       beforeCreate() {
         this.$inter =
-          this.$options.inter || (this.$parent && this.$parent.$options.inter)
+          this.$options.inter ||
+          (this.$parent && this.$parent.$options.inter) ||
+          (this.$root && this.$root.$options.inter)
         if (this.$inter) {
           this.$i = this.$inter.get.bind(this.$inter)
         }


### PR DESCRIPTION
When using vue-inter with vue-router, `this.$inter` returns undefined from the route components. This change should fix the issue.