### PR TITLE
add dot notation string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ Root component `App.vue`:
 </template>
 ```
 
+<details><summary>Dot-notation path</summary><br>
+
+```js
+// Object
+{
+  my: {
+    name: 'egoist'
+  },
+  'my.name': 'notegoist'
+}
+$inter.get('my.name') //=> egoist
+$inter.get('my\\.name') //=> notegoist
+```
+</details>
+
 <details><summary>Message templating</summary><br>
 
 By default `vue-inter` uses a simple templating syntax:

--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ Root component `App.vue`:
 <details><summary>Dot-notation path</summary><br>
 
 ```js
-// Object
+// Locale data
 {
   my: {
     name: 'egoist'
   },
   'my.name': 'notegoist'
 }
+// Get message by path
 $inter.get('my.name') //=> egoist
 $inter.get('my\\.name') //=> notegoist
 ```

--- a/example/index.js
+++ b/example/index.js
@@ -8,12 +8,16 @@ const inter = new Inter({
   locales: {
     en: {
       welcome_guest: 'Welcome guest',
-      my_age: 'I am {age} years old',
+      my: {
+        age: 'I am {age} years old'
+      },
       source_code: 'Check out the source code'
     },
     zh: {
       welcome_guest: '你好游客',
-      my_age: '我今年 {age} 岁',
+      my: {
+        age: '我今年 {age} 岁'
+      },
       source_code: '查看源代码'
     }
   }
@@ -34,7 +38,7 @@ new Vue({
       <input v-model={this.age} type="number" />
       <hr/>
       {this.$inter.get('welcome_guest')},{' '}
-      {this.$inter.get('my_age', { age: this.age })}
+      {this.$inter.get('my.age', { age: this.age })}
       <hr/>
       {this.$inter.get('source_code')}: <a href="https://github.com/egoist/vue-inter">https://github.com/egoist/vue-inter</a>
     </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "npm run lint && echo 'no tests!'",
+    "test": "npm run lint && tyu",
     "lint": "xo",
     "prepublishOnly": "npm run build",
     "build": "npm run build:cjs && npm run build:umd && npm run build:min",

--- a/src/get-prop.js
+++ b/src/get-prop.js
@@ -1,0 +1,21 @@
+function getPathSegments(path) {
+  const pathArr = path.split('.')
+  const parts = []
+
+  for (let i = 0; i < pathArr.length; i++) {
+    let p = pathArr[i]
+
+    while (p[p.length - 1] === '\\' && pathArr[i + 1] !== undefined) {
+      p = p.slice(0, -1) + '.'
+      p += pathArr[++i]
+    }
+
+    parts.push(p)
+  }
+
+  return parts
+}
+
+export default function(data, path) {
+  return getPathSegments(path).reduce((obj, k) => obj && obj[k], data)
+}

--- a/src/get-prop.test.js
+++ b/src/get-prop.test.js
@@ -1,0 +1,18 @@
+import getProp from './get-prop'
+
+const data = {
+  foo: 'foo',
+  bar: {
+    baz: 'baz'
+  },
+  'bar.baz': 'bar.baz'
+}
+
+test('main', () => {
+  expect(getProp(data, 'foo')).toBe('foo')
+  expect(getProp(data, 'bar.baz')).toBe('baz')
+  expect(getProp(data, 'bar\\.baz')).toBe('bar.baz')
+  expect(getProp(data, 'notexists')).toBeUndefined()
+  expect(getProp(data, 'not.exists')).toBeUndefined()
+  expect(getProp(data, 'not\\.exists')).toBeUndefined()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import defaultTemplate from './template'
+import getProp from './get-prop'
 
 let Vue
 
@@ -38,14 +39,14 @@ export default class Inter {
     return this.vm._data.$$locale
   }
 
-  get(key, ...data) {
+  get(path, ...data) {
     const localeData = this.locales[this.locale]
     if (process.env.NODE_ENV === 'development' && !localeData) {
       throw new Error(`[vue-inter] Locale "${this.locale}" was not found`)
     }
-    const message = key.split('.').reduce((o, i) => o[i], localeData)
+    const message = getProp(localeData, path)
     if (process.env.NODE_ENV === 'development' && !message) {
-      throw new Error(`[vue-inter] No message under "${key}" was found`)
+      throw new Error(`[vue-inter] No message under "${path}" was found`)
     }
     return this.template(message, ...data)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ export default class Inter {
     if (process.env.NODE_ENV === 'development' && !localeData) {
       throw new Error(`[vue-inter] Locale "${this.locale}" was not found`)
     }
-    const message = localeData[key]
+    const message = key.split('.').reduce((o, i) => o[i], localeData)
     if (process.env.NODE_ENV === 'development' && !message) {
       throw new Error(`[vue-inter] No message under "${key}" was found`)
     }


### PR DESCRIPTION
```javascript
locales: {
  en: {
    home: {
      cta: {
        value: 'Click here',
        ariaLabel: 'Click here for more info'
      }
    }
  }
}
```

Considering the above example, I was thinking that it would be good to be able to use a dot notation syntax like `$i('home.cta.value')` rather than being limited to `$i('home').cta.value`.